### PR TITLE
[Feat] 게시물 안에서 해시태그 추가하기

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtags.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtags.java
@@ -2,13 +2,13 @@ package com.example.ReviewZIP.domain.postHashtag;
 
 import com.example.ReviewZIP.domain.post.Posts;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "post_hashtags")
 public class PostHashtags {

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
@@ -1,0 +1,22 @@
+package com.example.ReviewZIP.domain.postHashtag;
+
+
+import com.example.ReviewZIP.global.response.ApiResponse;
+import com.example.ReviewZIP.global.response.code.resultCode.SuccessStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/hashtags")
+public class PostHashtagsController {
+
+    private final PostHashtagsService postHashtagsService;
+
+    @GetMapping("/{postId}")
+    public ApiResponse<SuccessStatus> addHashtags(@RequestParam String query, @PathVariable Long postId) {
+        postHashtagsService.addHashtags(query, postId);
+
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+}

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsRepository.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsRepository.java
@@ -1,0 +1,6 @@
+package com.example.ReviewZIP.domain.postHashtag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostHashtagsRepository extends JpaRepository<PostHashtags, Long> {
+}

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
@@ -1,0 +1,27 @@
+package com.example.ReviewZIP.domain.postHashtag;
+
+import com.example.ReviewZIP.domain.post.PostsRepository;
+import com.example.ReviewZIP.global.redis.RedisService;
+import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
+import com.example.ReviewZIP.global.response.exception.handler.PostsHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostHashtagsService {
+
+    private final PostHashtagsRepository postHashtagsRepository;
+    private final RedisService redisService;
+    private final PostsRepository postsRepository;
+
+    public void addHashtags(String query, Long postId) {
+        redisService.addHashtag(query);
+
+        PostHashtags postHashtags = PostHashtags.builder()
+                .hashtag(query)
+                .post(postsRepository.findById(postId).orElseThrow( () -> new PostsHandler(ErrorStatus.POST_NOT_FOUND)))
+                .build();
+        postHashtagsRepository.save(postHashtags);
+    }
+}

--- a/src/main/java/com/example/ReviewZIP/global/redis/RedisService.java
+++ b/src/main/java/com/example/ReviewZIP/global/redis/RedisService.java
@@ -1,9 +1,26 @@
 package com.example.ReviewZIP.global.redis;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class RedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void addHashtag(String query) {
+        HashOperations<String, String, String> hashOperations = redisTemplate.opsForHash();
+
+        if (hashOperations.hasKey("hashtags", query)) {
+            hashOperations.increment("hashtags", query, 1);
+        } else {
+            hashOperations.put("hashtags", query, "1");
+        }
+    }
+
 }

--- a/src/main/java/com/example/ReviewZIP/global/response/exception/handler/PostHashtagsHandler.java
+++ b/src/main/java/com/example/ReviewZIP/global/response/exception/handler/PostHashtagsHandler.java
@@ -1,0 +1,9 @@
+package com.example.ReviewZIP.global.response.exception.handler;
+
+import com.example.ReviewZIP.global.response.code.BaseErrorCode;
+import com.example.ReviewZIP.global.response.exception.GeneralException;
+
+public class PostHashtagsHandler extends GeneralException {
+    public PostHashtagsHandler(BaseErrorCode errorCode) {super(errorCode);}
+}
+


### PR DESCRIPTION
# 상세 구현 기능
사용자가 게시물 작성 시 해시태그를 입력하면 Redis에 해당 해시태그 이름을 가진 key에 해당하는 value의 값을 +1 증가 시키고 저장하며, RDBMS에는 PostHashtags 엔티티를 저장합니다.

## RedisService
```java
public void addHashtag(String query) {
        HashOperations<String, String, String> hashOperations = redisTemplate.opsForHash();

        if (hashOperations.hasKey("hashtags", query)) {
            hashOperations.increment("hashtags", query, 1);
        } else {
            hashOperations.put("hashtags", query, "1");
        }
    }
```
hashtags 안에 key, value 값을 사용자가 입력한 값, +1으로 저장합니다.

## PostHashtagsService
```java
 public void addHashtags(String query, Long postId) {
        redisService.addHashtag(query);

        PostHashtags postHashtags = PostHashtags.builder()
                .hashtag(query)
                .post(postsRepository.findById(postId).orElseThrow( () -> new PostsHandler(ErrorStatus.POST_NOT_FOUND)))
                .build();
        postHashtagsRepository.save(postHashtags);
    }
```
RDBMS에도 PostHashtags 값을 저장합니다. 

## PostHashtagsController
```java
@GetMapping("/{postId}")
    public ApiResponse<SuccessStatus> addHashtags(@RequestParam String query, @PathVariable Long postId) {
        postHashtagsService.addHashtags(query, postId);

        return ApiResponse.onSuccess(SuccessStatus._OK);
    }
```
postId값과 해시태그 이름을 넘기는 로직으로 구현했습니다.

## 질문 사항
X