### PR TITLE
[Feat] SearchHistories 엔티티 추가

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchHistories.java
+++ b/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchHistories.java
@@ -1,0 +1,28 @@
+package com.example.ReviewZIP.domain.searchHistory;
+
+import com.example.ReviewZIP.domain.post.Posts;
+import com.example.ReviewZIP.domain.user.Users;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "search_histories")
+public class SearchHistories {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    private String content;
+
+    private SearchType type;
+}

--- a/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchType.java
+++ b/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchType.java
@@ -1,0 +1,11 @@
+package com.example.ReviewZIP.domain.searchHistory;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SearchType {
+    USER,
+    HASHTAG
+}

--- a/src/main/java/com/example/ReviewZIP/domain/user/Users.java
+++ b/src/main/java/com/example/ReviewZIP/domain/user/Users.java
@@ -4,6 +4,7 @@ import com.example.ReviewZIP.domain.follow.Follows;
 import com.example.ReviewZIP.domain.post.Posts;
 import com.example.ReviewZIP.domain.postLike.PostLikes;
 import com.example.ReviewZIP.domain.scrab.Scrabs;
+import com.example.ReviewZIP.domain.searchHistory.SearchHistories;
 import com.example.ReviewZIP.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -65,4 +66,7 @@ public class Users extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<PostLikes> postLikeList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<SearchHistories> searchHistoriesList = new ArrayList<>();
 }


### PR DESCRIPTION
# 구현 설명
---

```java
@Entity
@Getter
@Setter
@NoArgsConstructor
@Table(name = "search_histories")
public class SearchHistories {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "id")
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "user_id")
    private Users user;

    private String content;

    private SearchType type;
}
```

- 유저와 해당 엔티티의 관계는 일대다로 진행하였습니다.

</br>

```java
@Getter
@RequiredArgsConstructor
public enum SearchType {
    USER,
    HASHTAG
}
```

- 해당 검색 타입을 지정하기 위해서 enum class를 새로 생성하였습니다.