### PR TITLE
[Feat] 해시태그 이름으로 해시태그 검색하기

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
@@ -1,6 +1,7 @@
 package com.example.ReviewZIP.domain.postHashtag;
 
 
+import com.example.ReviewZIP.domain.postHashtag.dto.response.PostHashtagResponseDto;
 import com.example.ReviewZIP.global.response.ApiResponse;
 import com.example.ReviewZIP.global.response.code.resultCode.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +12,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,5 +37,16 @@ public class PostHashtagsController {
         return ApiResponse.onSuccess(SuccessStatus._OK);
     }
 
-
+    @GetMapping("/search")
+    @Operation(summary = "해시태그 이름으로 해시태그를 검색 API", description = "해시태그 이름으로 검색 시 해시태그 리스트를 반환하고 검색기록에 저장")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name="hashtag", description = "해시태그 이름")
+    })
+    public ApiResponse<PostHashtagResponseDto.PostHashtagsPreviewListDto> searchHashtags(@RequestParam String hashtag) {
+        List<PostHashtags> postHashtagsList = postHashtagsService.searchHashtagsByName(hashtag);
+        return ApiResponse.onSuccess(PostHashtagsConverter.toPostHashtagsPreviewListDto(postHashtagsList));
+    }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsConverter.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsConverter.java
@@ -1,0 +1,27 @@
+package com.example.ReviewZIP.domain.postHashtag;
+
+import com.example.ReviewZIP.domain.postHashtag.dto.response.PostHashtagResponseDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PostHashtagsConverter {
+
+    public static PostHashtagResponseDto.PostHashtagsPreviewDto toPostHashtagsPreviewDto(PostHashtags postHashtags) {
+        return PostHashtagResponseDto.PostHashtagsPreviewDto.builder()
+                .id(postHashtags.getId())
+                .name(postHashtags.getHashtag())
+                .build();
+
+    }
+
+    public static PostHashtagResponseDto.PostHashtagsPreviewListDto toPostHashtagsPreviewListDto(List<PostHashtags> postHashtagsList){
+
+        List<PostHashtagResponseDto.PostHashtagsPreviewDto> postHashtagsPreviewDto = postHashtagsList.stream()
+                .map(PostHashtagsConverter::toPostHashtagsPreviewDto)
+                .collect(Collectors.toList());
+        return PostHashtagResponseDto.PostHashtagsPreviewListDto.builder()
+                .hashtagList(postHashtagsPreviewDto)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsRepository.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsRepository.java
@@ -3,10 +3,19 @@ package com.example.ReviewZIP.domain.postHashtag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 
 public interface PostHashtagsRepository extends JpaRepository<PostHashtags, Long> {
 
     Page<PostHashtags> findPostHashtagsById(Long id, PageRequest pageRequest);
+
+
+    @Query("SELECT ph FROM PostHashtags ph WHERE ph.hashtag LIKE %:name%")
+    List<PostHashtags> findByNameContaining(@Param("name") String name);
 
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
@@ -1,21 +1,34 @@
 package com.example.ReviewZIP.domain.postHashtag;
 
 import com.example.ReviewZIP.domain.post.PostsRepository;
+import com.example.ReviewZIP.domain.searchHistory.SearchHistories;
+import com.example.ReviewZIP.domain.searchHistory.SearchHistoriesRepository;
+import com.example.ReviewZIP.domain.searchHistory.SearchType;
+import com.example.ReviewZIP.domain.user.Users;
+import com.example.ReviewZIP.domain.user.UsersRepository;
 import com.example.ReviewZIP.global.redis.RedisService;
 import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
+import com.example.ReviewZIP.global.response.exception.handler.PostHashtagsHandler;
 import com.example.ReviewZIP.global.response.exception.handler.PostsHandler;
+import com.example.ReviewZIP.global.response.exception.handler.UsersHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class PostHashtagsService {
 
     private final PostHashtagsRepository postHashtagsRepository;
     private final RedisService redisService;
     private final PostsRepository postsRepository;
+    private final UsersRepository usersRepository;
+    private final SearchHistoriesRepository searchHistoriesRepository;
+
     @Transactional
     public void addHashtags(String query, Long postId) {
         redisService.addHashtag(query);
@@ -25,5 +38,26 @@ public class PostHashtagsService {
                 .post(postsRepository.findById(postId).orElseThrow( () -> new PostsHandler(ErrorStatus.POST_NOT_FOUND)))
                 .build();
         postHashtagsRepository.save(postHashtags);
+    }
+
+    public List<PostHashtags> searchHashtagsByName(String hashtag) {
+        List<PostHashtags> hashtagsList = postHashtagsRepository.findByNameContaining(hashtag);
+
+        // 임시적으로 유저 아이디 값에 1로 지정
+        Users users = usersRepository.findById(1L).orElseThrow(()-> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Optional<SearchHistories> existingRecord = searchHistoriesRepository.findByContentAndUser(hashtag, users);
+
+        if(existingRecord.isEmpty()) {
+
+            SearchHistories searchHistories = SearchHistories.builder()
+                    .content(hashtag)
+                    .type(SearchType.HASHTAG)
+                    .user(users)
+                    .build();
+
+            searchHistoriesRepository.save(searchHistories);
+        }
+
+        return hashtagsList;
     }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class PostHashtagsService {
 
     private final PostHashtagsRepository postHashtagsRepository;
@@ -42,21 +42,6 @@ public class PostHashtagsService {
 
     public List<PostHashtags> searchHashtagsByName(String hashtag) {
         List<PostHashtags> hashtagsList = postHashtagsRepository.findByNameContaining(hashtag);
-
-        // 임시적으로 유저 아이디 값에 1로 지정
-        Users users = usersRepository.findById(1L).orElseThrow(()-> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
-        Optional<SearchHistories> existingRecord = searchHistoriesRepository.findByContentAndUser(hashtag, users);
-
-        if(existingRecord.isEmpty()) {
-
-            SearchHistories searchHistories = SearchHistories.builder()
-                    .content(hashtag)
-                    .type(SearchType.HASHTAG)
-                    .user(users)
-                    .build();
-
-            searchHistoriesRepository.save(searchHistories);
-        }
 
         return hashtagsList;
     }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/dto/response/PostHashtagResponseDto.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/dto/response/PostHashtagResponseDto.java
@@ -1,0 +1,30 @@
+package com.example.ReviewZIP.domain.postHashtag.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class PostHashtagResponseDto {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostHashtagsPreviewDto {
+        private Long id;
+        private String name;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PostHashtagsPreviewListDto {
+        List<PostHashtagsPreviewDto> hashtagList;
+    }
+
+
+}


### PR DESCRIPTION
# 상세 구현 내용
해시태그 이름을 검색하면 해당하는 해시태그 이름이 포함된 해시태그 리스트를 반환합니다.

## PostHashtagsRepository
```java
public interface PostHashtagsRepository extends JpaRepository<PostHashtags, Long> {

    Page<PostHashtags> findPostHashtagsById(Long id, PageRequest pageRequest);


    @Query("SELECT ph FROM PostHashtags ph WHERE ph.hashtag LIKE %:name%")
    List<PostHashtags> findByNameContaining(@Param("name") String name);

}
```
입력한 해시태그 검색어가 포함된 해시태그를 반환합니다


## PostHashtagsService
```java
 public List<PostHashtags> searchHashtagsByName(String hashtag) {
        List<PostHashtags> hashtagsList = postHashtagsRepository.findByNameContaining(hashtag);

        // 임시적으로 유저 아이디 값에 1로 지정
        Users users = usersRepository.findById(1L).orElseThrow(()-> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
        Optional<SearchHistories> existingRecord = searchHistoriesRepository.findByContentAndUser(hashtag, users);

        if(existingRecord.isEmpty()) {

            SearchHistories searchHistories = SearchHistories.builder()
                    .content(hashtag)
                    .type(SearchType.HASHTAG)
                    .user(users)
                    .build();

            searchHistoriesRepository.save(searchHistories);
        }

        return hashtagsList;
    }
```
입력한 해시태그 검색어를 검색 기록에 저장하고 리포지토리를 통해 해시태그 리스트를 반환합니다.

## 이외 사항
이미 존재하는 해시태그 검색 관련 API는 해시태그로 검색 API는 게시글을 조회하는 API 입니다. 피그마 화면상으로는 
먼저 해당 API를 사용하는 페이지에서 해시태그로 검색을 진행하여 해시태그들을 보여주고 해당 해시태그를 클릭하면
관련 게시글을 보여주는 방식으로 작동됩니다.
