### PR TITLE
[Refactor] search histories 엔티티 수정

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchHistories.java
+++ b/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchHistories.java
@@ -22,7 +22,11 @@ public class SearchHistories {
     @JoinColumn(name = "user_id")
     private Users user;
 
-    private String content;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id")
+    private Users subject;
+
+    private String hashtag;
 
     @Enumerated(EnumType.STRING)
     private SearchType type;

--- a/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchHistoriesRepository.java
+++ b/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchHistoriesRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface SearchHistoriesRepository extends JpaRepository<SearchHistories, Long> {
-    Optional<SearchHistories> findByContentAndUser(String name, Users users);
+
 }

--- a/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchType.java
+++ b/src/main/java/com/example/ReviewZIP/domain/searchHistory/SearchType.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SearchType {
-    NAME,
-    NICKNAME,
+    USER,
     HASHTAG
 }

--- a/src/main/java/com/example/ReviewZIP/domain/user/Users.java
+++ b/src/main/java/com/example/ReviewZIP/domain/user/Users.java
@@ -8,7 +8,6 @@ import com.example.ReviewZIP.domain.searchHistory.SearchHistories;
 import com.example.ReviewZIP.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -69,4 +68,7 @@ public class Users extends BaseEntity {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<SearchHistories> searchHistoriesList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "subject", cascade = CascadeType.ALL)
+    private List<SearchHistories> subjectList = new ArrayList<>();
 }


### PR DESCRIPTION
# 상세 구현 설명
---

- 검색어를 String으로 저장하여 검색된 유저를 찾을 수 없어 String 값대신 user를 저장하도록 수정하였습니다.

```java
@Table(name = "search_histories")
public class SearchHistories {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "id")
    private Long id;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "user_id")
    private Users user;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "subject_id")
    private Users subject;

    private String hashtag;

    @Enumerated(EnumType.STRING)
    private SearchType type;
}
```

- 그에 따른 SearchType도 변경하였습니다.

```java
@Getter
@RequiredArgsConstructor
public enum SearchType {
    USER,
    HASHTAG
}
```