### PR TITLE
[Fix] CorsConfig 관련 코드 수정 

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "로컬 로그인/회원가입", description = "로컬 로그인, 회원가입 API")
+@Tag(name = "token-controller", description = "로컬 로그인, 회원가입 API")
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor

--- a/src/main/java/com/example/ReviewZIP/global/security/CorsConfig.java
+++ b/src/main/java/com/example/ReviewZIP/global/security/CorsConfig.java
@@ -6,6 +6,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
+import java.util.List;
+
 @Configuration
 public class CorsConfig {
     @Bean
@@ -15,7 +17,7 @@ public class CorsConfig {
         config.setAllowCredentials(true);
         config.addAllowedOriginPattern("*");
         config.addAllowedHeader("*");
-        config.addAllowedMethod("*");
+        config.setAllowedMethods(List.of("POST", "GET", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.addAllowedOrigin("https://api.egusajo.shop");
 
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/com/example/ReviewZIP/global/security/WebSecurityConfig.java
+++ b/src/main/java/com/example/ReviewZIP/global/security/WebSecurityConfig.java
@@ -4,6 +4,7 @@ import com.example.ReviewZIP.global.jwt.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -12,7 +13,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -20,7 +20,7 @@ import org.springframework.web.filter.CorsFilter;
 public class WebSecurityConfig {
 
     private final JwtProvider jwtProvider;
-    private final CorsFilter corsFilter;
+    private final CorsConfig corsConfig;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtRequestFilter jwtRequestFilter;
@@ -28,7 +28,7 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
         http
-                .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(corsConfig.corsFilter(), UsernamePasswordAuthenticationFilter.class)
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
@@ -36,15 +36,16 @@ public class WebSecurityConfig {
                         .requestMatchers(new AntPathRequestMatcher("/auth/**")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/S3/**")).permitAll()
                         .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**", "/").permitAll()
+                        .requestMatchers("https://api.egusajo.shop ").permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated())
 
                 .exceptionHandling(exceptionHandling -> exceptionHandling
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                         .accessDeniedHandler(jwtAccessDeniedHandler))
 
-                // JwtFilter를 addFilterBefore로 등록했던 JwtSecurityConfig 클래스를 적용
-                .apply(new JwtSecurityConfig(jwtProvider));
-
+                // apply가 deprecated 되서 JwtRequestFilter에서 직접 설정한 필터를 추가
+                .addFilterBefore(new JwtRequestFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();
 
     }


### PR DESCRIPTION
# 수정 내용
## CorsConfig
```java
@Configuration
public class CorsConfig {
    @Bean
    public CorsFilter corsFilter() {
        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
        CorsConfiguration config = new CorsConfiguration();
        config.setAllowCredentials(true);
        config.addAllowedOriginPattern("*");
        config.addAllowedHeader("*");
        config.setAllowedMethods(List.of("POST", "GET", "PUT", "DELETE", "PATCH", "OPTIONS"));
        config.addAllowedOrigin("https://api.egusajo.shop");

        source.registerCorsConfiguration("/**", config);
        return new CorsFilter(source);
    }
}
```
"*"으로 보안을 모두 허용했지만, HTTP 메소드만 허용하기 위해 관련 메소드만 요청 허용하기로 코드를 변경했습니다.

## WebSecurityConfig
```java
   @Bean
    public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
        http
                .addFilterBefore(corsConfig.corsFilter(), UsernamePasswordAuthenticationFilter.class)
                .csrf(AbstractHttpConfigurer::disable)
                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                .authorizeHttpRequests(authorize -> authorize
                        .requestMatchers("/", "/**").permitAll()
                        .requestMatchers(new AntPathRequestMatcher("/auth/**")).permitAll()
                        .requestMatchers(new AntPathRequestMatcher("/S3/**")).permitAll()
                        .requestMatchers("/swagger-resources/**", "/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**", "/").permitAll()
                        .requestMatchers("https://api.egusajo.shop ").permitAll()
                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                        .anyRequest().authenticated())

                .exceptionHandling(exceptionHandling -> exceptionHandling
                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                        .accessDeniedHandler(jwtAccessDeniedHandler))

                // apply가 deprecated 되서 JwtRequestFilter에서 직접 설정한 필터를 추가
                .addFilterBefore(new JwtRequestFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
        return http.build();

    }
```
필터링 작업 전에 CorsConfig가 먼저 적용되어야 하므로 관련 코드를 수정했습니다. 그리고 requestMatchers에 배포 서퍼 관련 URL을 추가해 관련 URL 요청이 오면 모두 허용하는걸로 코드를 변경했습니다. 그리고 apply 메소드가 deprecated 되었으므로 addFilterBefore 메소드를 적용해 해당 코드를 최신 버전에 맞게 적용했습니다.
