### PR TITLE
[Fix] 함수 디렉토리 변경 및 게시물 가져오기 오류 수정

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,6 +23,21 @@ import java.util.List;
 public class PostsController {
 
     private final PostsService postsService;
+
+    @GetMapping("/{postId}/hashtags")
+    @Operation(summary = "게시물에 해시태그 추가 API", description = "게시물에 해시태그를 추가")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+    })
+    @Parameters({
+            @Parameter(name="postId", description = "작성하는 게시물 ID"),
+            @Parameter(name="query", description = "해시태그 이름")
+    })
+    public ApiResponse<SuccessStatus> addHashtags(@RequestParam String query, @PathVariable Long postId) {
+        postsService.addHashtags(query, postId);
+
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
 
     @GetMapping("/hashtags/{hashtagId}")
     @Operation(summary = "해시태그 아이디로 게시글을 찾는 API",description = "해시태그 아이디로 게시글을 찾는 기능, 반환 시 PostPreviewListDto, PostPreviewDto 사용")

--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsService.java
@@ -14,6 +14,7 @@ import com.example.ReviewZIP.domain.scrab.Scrabs;
 import com.example.ReviewZIP.domain.scrab.ScrabsRepository;
 import com.example.ReviewZIP.domain.user.Users;
 import com.example.ReviewZIP.domain.user.UsersRepository;
+import com.example.ReviewZIP.global.redis.RedisService;
 import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
 import com.example.ReviewZIP.global.response.exception.handler.*;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,7 @@ public class PostsService {
     private final PostLikesRepository postLikesRepository;
     private final ScrabsRepository scrabsRepository;
     private final PostHashtagsRepository postHashtagsRepository;
-    private final FollowsRepository followsRepository;
+    private final RedisService redisService;
 
     public List<PostHashtags> searchPostByHashtag (Long hashtagId){
         PostHashtags postHashtags = postHashtagsRepository.findById(hashtagId).orElseThrow(()->new PostHashtagsHandler(ErrorStatus.HASHTAG_NOT_FOUND));
@@ -256,5 +257,16 @@ public class PostsService {
         Scrabs scrabs = scrabsRepository.findByUserAndPost(me, post);
 
         scrabsRepository.delete(scrabs);
+    }
+
+    @Transactional
+    public void addHashtags(String query, Long postId) {
+        redisService.addHashtag(query);
+
+        PostHashtags postHashtags = PostHashtags.builder()
+                .hashtag(query)
+                .post(postsRepository.findById(postId).orElseThrow( () -> new PostsHandler(ErrorStatus.POST_NOT_FOUND)))
+                .build();
+        postHashtagsRepository.save(postHashtags);
     }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
@@ -7,6 +7,8 @@ import com.example.ReviewZIP.global.response.code.resultCode.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -22,20 +24,6 @@ public class PostHashtagsController {
 
     private final PostHashtagsService postHashtagsService;
 
-    @GetMapping("/{postId}")
-    @Operation(summary = "게시물에 해시태그 추가 API", description = "게시물에 해시태그를 추가")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
-    })
-    @Parameters({
-            @Parameter(name="postId", description = "작성하는 게시물 ID"),
-            @Parameter(name="query", description = "해시태그 이름")
-    })
-    public ApiResponse<SuccessStatus> addHashtags(@RequestParam String query, @PathVariable Long postId) {
-        postHashtagsService.addHashtags(query, postId);
-
-        return ApiResponse.onSuccess(SuccessStatus._OK);
-    }
 
     @GetMapping("/search")
     @Operation(summary = "해시태그 이름으로 해시태그를 검색 API", description = "해시태그 이름으로 검색 시 해시태그 리스트를 반환하고 검색기록에 저장, PostHashtagsPreviewDto 이용")
@@ -48,5 +36,19 @@ public class PostHashtagsController {
     public ApiResponse<List<PostHashtagResponseDto.PostHashtagsPreviewDto>> searchHashtags(@RequestParam String hashtag) {
         List<PostHashtags> postHashtagsList = postHashtagsService.searchHashtagsByName(hashtag);
         return ApiResponse.onSuccess(PostHashtagsConverter.toPostHashtagsPreviewListDto(postHashtagsList));
+    }
+
+    @GetMapping("/{hashtagId}")
+    @Operation(summary = "해시태그 아이디로 해시태그 조회 API", description = "해시태그 id로 해당 해시태그 객체 반환, PostHashtagsPreviewDto 이용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "HASHTAG401", description = "해당하는 해시태그가 존재하지 않음.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name="hashtagId", description = "해시태그 아이디")
+    })
+    public ApiResponse<PostHashtagResponseDto.PostHashtagsPreviewDto> getHashtag(@PathVariable(name="hashtagId")Long hashtagId){
+        PostHashtags hashtag = postHashtagsService.getPostHashtag(hashtagId);
+        return ApiResponse.onSuccess(PostHashtagsConverter.toPostHashtagsPreviewDto(hashtag));
     }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsRepository.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsRepository.java
@@ -11,7 +11,6 @@ public interface PostHashtagsRepository extends JpaRepository<PostHashtags, Long
 
     List<PostHashtags> findAllByHashtag(String hashtag);
 
-
     @Query("SELECT ph FROM PostHashtags ph WHERE ph.hashtag LIKE %:name% GROUP BY ph.hashtag"  )
     List<PostHashtags> findByNameContaining(@Param("name") String name);
 

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
@@ -5,6 +5,7 @@ import com.example.ReviewZIP.domain.searchHistory.SearchHistoriesRepository;
 import com.example.ReviewZIP.domain.user.UsersRepository;
 import com.example.ReviewZIP.global.redis.RedisService;
 import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
+import com.example.ReviewZIP.global.response.exception.handler.PostHashtagsHandler;
 import com.example.ReviewZIP.global.response.exception.handler.PostsHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,23 +19,14 @@ import java.util.List;
 public class PostHashtagsService {
 
     private final PostHashtagsRepository postHashtagsRepository;
-    private final RedisService redisService;
-    private final PostsRepository postsRepository;
-
-    @Transactional
-    public void addHashtags(String query, Long postId) {
-        redisService.addHashtag(query);
-
-        PostHashtags postHashtags = PostHashtags.builder()
-                .hashtag(query)
-                .post(postsRepository.findById(postId).orElseThrow( () -> new PostsHandler(ErrorStatus.POST_NOT_FOUND)))
-                .build();
-        postHashtagsRepository.save(postHashtags);
-    }
 
     public List<PostHashtags> searchHashtagsByName(String hashtag) {
         List<PostHashtags> hashtagsList = postHashtagsRepository.findByNameContaining(hashtag);
 
         return hashtagsList;
+    }
+
+    public PostHashtags getPostHashtag(Long hashtagId){
+        return postHashtagsRepository.findById(hashtagId).orElseThrow(()->new PostHashtagsHandler(ErrorStatus.HASHTAG_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/user/UsersController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/user/UsersController.java
@@ -84,7 +84,7 @@ public class UsersController {
     public ApiResponse<List<UserResponseDto.UserPreviewDto>> getUserFollowingList(){
         List<Follows> FollowingList = usersService.getFollowingList(1L); //수정 필요
         List<Long> followingIdList = usersService.getFollowigIdList(1L);
-        return ApiResponse.onSuccess(UsersConverter.toFollowPreviewListDto(FollowingList, followingIdList));
+        return ApiResponse.onSuccess(UsersConverter.toFollowingPreviewListDto(FollowingList, followingIdList));
     }
 
     @GetMapping("/me/followers")
@@ -98,7 +98,7 @@ public class UsersController {
         List<Follows> FollowerList = usersService.getFollowerList(1L); //수정 필요
         List<Long> followingIdList = usersService.getFollowigIdList(1L);
 
-        return ApiResponse.onSuccess(UsersConverter.toFollowPreviewListDto(FollowerList, followingIdList));
+        return ApiResponse.onSuccess(UsersConverter.toFollowerPreviewListDto(FollowerList, followingIdList));
     }
 
     @GetMapping("/{userId}/followings")
@@ -113,7 +113,7 @@ public class UsersController {
     public ApiResponse<List<UserResponseDto.UserPreviewDto>> getOtherFollowingList(@PathVariable(name = "userId") Long userId){
         List<Follows> FollowingList = usersService.getFollowingList(userId);
         List<Long> followingIdList = usersService.getFollowigIdList(userId);
-        return ApiResponse.onSuccess(UsersConverter.toFollowPreviewListDto(FollowingList, followingIdList));
+        return ApiResponse.onSuccess(UsersConverter.toFollowingPreviewListDto(FollowingList, followingIdList));
     }
 
     @GetMapping("/{userId}/followers")
@@ -128,7 +128,7 @@ public class UsersController {
     public ApiResponse<List<UserResponseDto.UserPreviewDto>> getOtherFollowerList(@PathVariable(name = "userId")Long userId){
         List<Follows> FollowerList = usersService.getFollowerList(userId);
         List<Long> followingIdList = usersService.getFollowigIdList(userId);
-        return ApiResponse.onSuccess(UsersConverter.toFollowPreviewListDto(FollowerList, followingIdList));
+        return ApiResponse.onSuccess(UsersConverter.toFollowerPreviewListDto(FollowerList, followingIdList));
     }
 
     @GetMapping("/me/posts")

--- a/src/main/java/com/example/ReviewZIP/domain/user/UsersConverter.java
+++ b/src/main/java/com/example/ReviewZIP/domain/user/UsersConverter.java
@@ -31,7 +31,7 @@ public class UsersConverter {
     }
 
     // 팔로잉 목록 converter
-    public static UserResponseDto.UserPreviewDto toFollowPreviewDto(Follows follows, List<Long> followingIdList){
+    public static UserResponseDto.UserPreviewDto toFollowingPreviewDto(Follows follows, List<Long> followingIdList){
         boolean isFollowing = followingIdList.contains(follows.getReceiver().getId());
         return UserResponseDto.UserPreviewDto.builder()
                 .userId(follows.getReceiver().getId())
@@ -42,9 +42,26 @@ public class UsersConverter {
                 .build();
     }
 
-    public static List<UserResponseDto.UserPreviewDto> toFollowPreviewListDto(List<Follows> followsList, List<Long> followingIdList){
+    public static List<UserResponseDto.UserPreviewDto> toFollowingPreviewListDto(List<Follows> followsList, List<Long> followingIdList){
         return followsList.stream()
-                .map(follow -> toFollowPreviewDto(follow, followingIdList)).collect(Collectors.toList());
+                .map(follow -> toFollowingPreviewDto(follow, followingIdList)).collect(Collectors.toList());
+
+    }
+
+    public static UserResponseDto.UserPreviewDto toFollowerPreviewDto(Follows follows, List<Long> followingIdList){
+        boolean isFollowing = followingIdList.contains(follows.getSender().getId());
+        return UserResponseDto.UserPreviewDto.builder()
+                .userId(follows.getSender().getId())
+                .name(follows.getSender().getName())
+                .profileUrl(follows.getSender().getProfileUrl())
+                .nickname(follows.getSender().getNickname())
+                .following(isFollowing)
+                .build();
+    }
+
+    public static List<UserResponseDto.UserPreviewDto> toFollowerPreviewListDto(List<Follows> followsList, List<Long> followingIdList){
+        return followsList.stream()
+                .map(follow -> toFollowerPreviewDto(follow, followingIdList)).collect(Collectors.toList());
 
     }
 

--- a/src/main/java/com/example/ReviewZIP/domain/user/UsersService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/user/UsersService.java
@@ -81,14 +81,13 @@ public class UsersService {
     }
 
     public UserResponseDto.UserInfoDto getUserInfo(Long userId){
-        // 사용자 임의 처리, 1L 가정
-        Users me = usersRepository.getById(1L);
+        Users me = usersRepository.getById(userId);
 
         return UsersConverter.toUserInfoDto(me);
     }
     public UserResponseDto.OtherUserInfoDto getOtherInfo(Long userId){
         // 사용자 임의 처리, 1L 가정
-        Users me = usersRepository.getById(1L);
+        Users me = usersRepository.getById(userId);
         Users other = usersRepository.findById(userId)
                 .orElseThrow(()->new UsersHandler(ErrorStatus.USER_NOT_FOUND));
 
@@ -129,8 +128,7 @@ public class UsersService {
     }
 
     public PostResponseDto.PostInfoDto getPostInfoDto(Long postId, Long userId){
-        // 좋아요와 스크랩 표시를 위하여 1L로 해당 유저를 대체
-        Users user = usersRepository.getById(1L);
+        Users user = usersRepository.getById(userId);
         Posts post = postsRepository.findById(postId).orElseThrow(()->new PostsHandler(ErrorStatus.POST_NOT_FOUND));
         boolean checkLike = postLikesRepository.existsByUserAndPost(user, post);
         boolean checkScrab = scrabsRepository.existsByUserAndPost(user, post);
@@ -148,18 +146,18 @@ public class UsersService {
 
     List<PostResponseDto.PostInfoDto> getScrabInfoDtoList(Long userId, List<Scrabs> scrabList){
         return scrabList.stream()
-                .map(scrab -> getPostInfoDto(scrab.getPost().getId(), 1L))
+                .map(scrab -> getPostInfoDto(scrab.getPost().getId(), userId))
                 .collect(Collectors.toList());
     }
 
 
     List<Posts> getPostList(Long userId){
-        Users me = usersRepository.getById(1L);
+        Users me = usersRepository.getById(userId);
         return me.getPostList();
     }
 
     List<Scrabs> getScrabList(Long userId){
-        Users me = usersRepository.getById(1L);
+        Users me = usersRepository.getById(userId);
         return me.getScrabList();
     }
 }


### PR DESCRIPTION
# 변경사항
---
- 게시물에 해시태그 추가하기 API 이동 (PostHashtags -> Post) 그에따른 url 변경
- 특정유저가 쓴 게시물들, 혹은 스크랩한 게시물들 반환값 수정
- 해시태그 id로 해시태그 찾기 API 추가