### PR TITLE
[Refactor] 해시태그 정보 게시글 갯수 추가

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsRepository.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsRepository.java
@@ -15,6 +15,4 @@ public interface PostsRepository extends JpaRepository<Posts, Long> {
     long countByUserNot(@Param("user") Users user);
 
     Page<Posts> findAllByUserNot(Users user, PageRequest pageRequest);
-
-
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 @RestController
@@ -49,6 +50,7 @@ public class PostHashtagsController {
     })
     public ApiResponse<PostHashtagResponseDto.PostHashtagsPreviewDto> getHashtag(@PathVariable(name="hashtagId")Long hashtagId){
         PostHashtags hashtag = postHashtagsService.getPostHashtag(hashtagId);
-        return ApiResponse.onSuccess(PostHashtagsConverter.toPostHashtagsPreviewDto(hashtag));
+        Integer postNum = postHashtagsService.getPostNumByHashtag(hashtag);
+        return ApiResponse.onSuccess(PostHashtagsConverter.toPostHashtagsPreviewDto(hashtag, postNum));
     }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsController.java
@@ -3,7 +3,6 @@ package com.example.ReviewZIP.domain.postHashtag;
 
 import com.example.ReviewZIP.domain.postHashtag.dto.response.PostHashtagResponseDto;
 import com.example.ReviewZIP.global.response.ApiResponse;
-import com.example.ReviewZIP.global.response.code.resultCode.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -13,10 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsConverter.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsConverter.java
@@ -1,25 +1,38 @@
 package com.example.ReviewZIP.domain.postHashtag;
 
 import com.example.ReviewZIP.domain.postHashtag.dto.response.PostHashtagResponseDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
+@Component
 public class PostHashtagsConverter {
 
-    public static PostHashtagResponseDto.PostHashtagsPreviewDto toPostHashtagsPreviewDto(PostHashtags postHashtags) {
+    public static PostHashtagsRepository postHashtagsRepository;
+
+    public PostHashtagsConverter(PostHashtagsRepository postHashtagsRepository) {
+        this.postHashtagsRepository = postHashtagsRepository;
+    }
+
+
+    public static PostHashtagResponseDto.PostHashtagsPreviewDto toPostHashtagsPreviewDto(PostHashtags postHashtags, int postNum) {
         return PostHashtagResponseDto.PostHashtagsPreviewDto.builder()
                 .hashtagId(postHashtags.getId())
                 .tagName(postHashtags.getHashtag())
+                .postNum(postNum)
                 .build();
 
     }
 
     public static List<PostHashtagResponseDto.PostHashtagsPreviewDto> toPostHashtagsPreviewListDto(List<PostHashtags> postHashtagsList){
-
         return postHashtagsList.stream()
-                .map(PostHashtagsConverter::toPostHashtagsPreviewDto)
+                .map(postHashtags -> {
+                        int postNum = postHashtagsRepository.countPostByHashtag(postHashtags.getHashtag());
+                        return toPostHashtagsPreviewDto(postHashtags, postNum);})
                 .collect(Collectors.toList());
     }
+
+
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsRepository.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsRepository.java
@@ -14,4 +14,5 @@ public interface PostHashtagsRepository extends JpaRepository<PostHashtags, Long
     @Query("SELECT ph FROM PostHashtags ph WHERE ph.hashtag LIKE %:name% GROUP BY ph.hashtag"  )
     List<PostHashtags> findByNameContaining(@Param("name") String name);
 
+    Integer countPostByHashtag(String hashtag);
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/PostHashtagsService.java
@@ -29,4 +29,10 @@ public class PostHashtagsService {
     public PostHashtags getPostHashtag(Long hashtagId){
         return postHashtagsRepository.findById(hashtagId).orElseThrow(()->new PostHashtagsHandler(ErrorStatus.HASHTAG_NOT_FOUND));
     }
+
+    public Integer getPostNumByHashtag(PostHashtags hashtag){
+        List<PostHashtags> hashtagsList = postHashtagsRepository.findAllByHashtag(hashtag.getHashtag());
+        return hashtagsList.size();
+
+    }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/postHashtag/dto/response/PostHashtagResponseDto.java
+++ b/src/main/java/com/example/ReviewZIP/domain/postHashtag/dto/response/PostHashtagResponseDto.java
@@ -16,5 +16,7 @@ public class PostHashtagResponseDto {
     public static class PostHashtagsPreviewDto {
         private Long hashtagId;
         private String tagName;
+        private Integer postNum;
     }
+
 }


### PR DESCRIPTION
# 상세구현설명
---

## PostHashtagsConverter

```java
public static PostHashtagResponseDto.PostHashtagsPreviewDto toPostHashtagsPreviewDto(PostHashtags postHashtags, int postNum) {
        return PostHashtagResponseDto.PostHashtagsPreviewDto.builder()
                .hashtagId(postHashtags.getId())
                .tagName(postHashtags.getHashtag())
                .postNum(postNum)
                .build();

    }

    public static List<PostHashtagResponseDto.PostHashtagsPreviewDto> toPostHashtagsPreviewListDto(List<PostHashtags> postHashtagsList){
        return postHashtagsList.stream()
                .map(postHashtags -> {
                        int postNum = postHashtagsRepository.countPostByHashtag(postHashtags.getHashtag());
                        return toPostHashtagsPreviewDto(postHashtags, postNum);})
                .collect(Collectors.toList());
    }
```

- 해당 해시태그를 갖는 게시글이 몇개인지에 대한 정보를 추가하였습니다.

</br>

## PostHashtagResponseDto

```java
    @Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class PostHashtagsPreviewDto {
        private Long hashtagId;
        private String tagName;
        private Integer postNum;
    }
```

</br>

# 데이터베이스
---
- '인하' 검색결과
```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": [
    {
      "hashtagId": 32,
      "tagName": "인하대",
      "postNum": 4
    },
    {
      "hashtagId": 45,
      "tagName": "인하",
      "postNum": 1
    }
  ]
}
```