### PR TITLE
[Refactor] 생성함수 중복처리

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/follow/FollowsController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/follow/FollowsController.java
@@ -31,9 +31,8 @@ public class FollowsController {
             @Parameter(name = "userId", description = "팔로우할 유저의 아이디"),
     })
     public ApiResponse<SuccessStatus> follow(@PathVariable(name="userId") Long userId) {
-        Follows follows = followsService.createFollowing(userId);
 
-        return ApiResponse.onSuccess(SuccessStatus._OK);
+        return followsService.createFollowing(userId);
     }
 
     @DeleteMapping("/users/{userId}")
@@ -46,8 +45,7 @@ public class FollowsController {
             @Parameter(name = "userId", description = "팔로우 취소할 유저의 아이디"),
     })
     public ApiResponse<SuccessStatus> unfollowUser(@PathVariable(name="userId")Long userId){
-        followsService.unfollowUser(userId);
 
-        return ApiResponse.onSuccess(SuccessStatus._OK);
+        return followsService.unfollowUser(userId);
     }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/follow/FollowsService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/follow/FollowsService.java
@@ -3,7 +3,9 @@ package com.example.ReviewZIP.domain.follow;
 
 import com.example.ReviewZIP.domain.user.Users;
 import com.example.ReviewZIP.domain.user.UsersRepository;
+import com.example.ReviewZIP.global.response.ApiResponse;
 import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
+import com.example.ReviewZIP.global.response.code.resultCode.SuccessStatus;
 import com.example.ReviewZIP.global.response.exception.handler.UsersHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,21 +20,23 @@ public class FollowsService {
 
 
     @Transactional
-    public Follows createFollowing(Long userId) {
+    public ApiResponse<SuccessStatus> createFollowing(Long userId) {
         Users sender = usersRepository.getById(1L);
         Users receiver = usersRepository.findById(userId).orElseThrow(() -> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
-
+        boolean alreadyFollow = followsRepository.existsBySenderAndReceiver(sender, receiver);
+        if(alreadyFollow)
+            return ApiResponse.onSuccess(SuccessStatus._OK);
         Follows newFollow = FollowsConverter.toFollows(sender, receiver);
-        return followsRepository.save(newFollow);
+        followsRepository.save(newFollow);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
     }
 
     @Transactional
-    public void unfollowUser(Long userId){
+    public ApiResponse<SuccessStatus> unfollowUser(Long userId){
         Users sender = usersRepository.findById(1L).orElseThrow(()->new UsersHandler(ErrorStatus.USER_NOT_FOUND));
         Users receiver = usersRepository.findById(userId).orElseThrow(()->new  UsersHandler(ErrorStatus.USER_NOT_FOUND));
-
         Follows unfollow = followsRepository.getBySenderAndReceiver(sender, receiver);
-
         followsRepository.delete(unfollow);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
     }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsController.java
@@ -147,8 +147,8 @@ public class PostsController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POSTLIKE402", description = "이미 공감한 게시물",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     public ApiResponse<SuccessStatus> addPostLike(@PathVariable(name = "postId") Long postId ) {
-        postsService.addLike(postId);
-        return ApiResponse.onSuccess(SuccessStatus.POST_CHOOSE_LIKE_SUCCESS);
+
+        return postsService.addLike(postId);
     }
 
     @DeleteMapping("/{postId}/like")
@@ -169,8 +169,7 @@ public class PostsController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "해당하는 게시글이 존재하지 않음",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     public ApiResponse<SuccessStatus> createScrabs(@PathVariable(name = "postid")Long postId){
-        postsService.createScrabs(postId);
-        return ApiResponse.onSuccess(SuccessStatus._OK);
+        return postsService.createScrabs(postId);
     }
 
     @DeleteMapping("/{postid}/scrabs")

--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsService.java
@@ -14,7 +14,9 @@ import com.example.ReviewZIP.domain.scrab.ScrabsRepository;
 import com.example.ReviewZIP.domain.user.Users;
 import com.example.ReviewZIP.domain.user.UsersRepository;
 import com.example.ReviewZIP.global.redis.RedisService;
+import com.example.ReviewZIP.global.response.ApiResponse;
 import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
+import com.example.ReviewZIP.global.response.code.resultCode.SuccessStatus;
 import com.example.ReviewZIP.global.response.exception.handler.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -196,18 +198,22 @@ public class PostsService {
         postLikesRepository.delete(postLikes);
     }
     @Transactional
-    public void addLike(Long postId) {
+    public ApiResponse<SuccessStatus> addLike(Long postId) {
         // user 1L로 대체
         Users user = usersRepository.getById(1L);
         Posts post = postsRepository.findById(postId).orElseThrow(() -> new PostLikesHandler(ErrorStatus.POST_NOT_FOUND));
-
+        boolean alreadyLike = postLikesRepository.existsByUserAndPost(user, post);
+        if(alreadyLike){
+            return ApiResponse.onSuccess(SuccessStatus._OK);
+        }
         PostLikes postLikes = PostLikes.builder()
                 .post(post)
                 .user(user)
                 .build();
 
+        postLikesRepository.save(postLikes);
         try {
-            PostLikes result = postLikesRepository.save(postLikes);
+            return ApiResponse.onSuccess(SuccessStatus._OK);
         } catch (Exception e) {
             throw new PostLikesHandler(ErrorStatus.POSTLIKE_CREATE_FAIL);
         }
@@ -233,17 +239,21 @@ public class PostsService {
     }
 
     @Transactional
-    public void createScrabs(Long postId){
+    public ApiResponse<SuccessStatus> createScrabs(Long postId){
         // userId는 1로 대체
         Users me = usersRepository.getById(1L);
         Posts post = postsRepository.findById(postId).orElseThrow(()->new PostsHandler(ErrorStatus.POST_NOT_FOUND));
-
+        boolean alreadyScrab = scrabsRepository.existsByUserAndPost(me, post);
+        if(alreadyScrab){
+            return ApiResponse.onSuccess(SuccessStatus._OK);
+        }
         Scrabs newScrab = Scrabs.builder()
                 .user(me)
                 .post(post)
                 .build();
 
         scrabsRepository.save(newScrab);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
     }
 
     @Transactional


### PR DESCRIPTION
# 변경사항 설명
---
- 프론트의 요청으로 아래 기능 중복 요청시 성공코드를 보내도록 수정

- 포스트에 공감누르기 API
- 팔로우하기 API
- 게시글에 스크랩 누르기 API

</br>

```java
    @Transactional
    public ApiResponse<SuccessStatus> createFollowing(Long userId) {
        --- 생략 ---
        boolean alreadyFollow = followsRepository.existsBySenderAndReceiver(sender, receiver);
        if(alreadyFollow)
            return ApiResponse.onSuccess(SuccessStatus._OK);
       --- 생략 ---
    }
```
- 위 두개의 코드도 동일하게 수정되었습니다.
