### PR TITLE
[feat]  관심 장소 해제 기능

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresController.java
@@ -25,6 +25,8 @@ public class UserStoresController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "유저가 존재하지 않습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USERSTORE401", description = "유저 관심장소 저장에 실패했습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+
     })
     public ApiResponse<SuccessStatus> createUserStores(@RequestBody UserStoresRequestDto.CreateUserStoresDto dto) {
         userStoresService.createUserStores(dto);
@@ -47,11 +49,13 @@ public class UserStoresController {
         return ApiResponse.onSuccess(userStoresService.isInterestPlace(lat,lon));
     }
 
-    @DeleteMapping("/{storeId}/")
+    @DeleteMapping("/{storeId}")
     @Operation(summary = "기존의 관심장소를 해제하는 API",description = "관심장소의 아이디를 입력받아 관심장소를 해제하는 기능")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "유저가 존재하지 않습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USERSTORE402", description = "유저 관심장소 삭제에 실패했습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+
     })
     @Parameters({
             @Parameter(name = "storeId", description = "장소의 아이디"),

--- a/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresController.java
@@ -47,4 +47,19 @@ public class UserStoresController {
         return ApiResponse.onSuccess(userStoresService.isInterestPlace(lat,lon));
     }
 
+    @DeleteMapping("/{storeId}/")
+    @Operation(summary = "기존의 관심장소를 해제하는 API",description = "관심장소의 아이디를 입력받아 관심장소를 해제하는 기능")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "유저가 존재하지 않습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "storeId", description = "장소의 아이디"),
+
+    })
+    public ApiResponse<SuccessStatus> deleteUserStores(@PathVariable Long storeId) {
+        userStoresService.deleteUserStores(storeId);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
 }

--- a/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresRepository.java
+++ b/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresRepository.java
@@ -11,4 +11,6 @@ public interface UserStoresRepository extends JpaRepository<UserStores, Long> {
     List<UserStores> findAllByUser (Users user);
 
     Boolean existsUserStoresByLatitudeAndLongitude (Double latitude, Double longitude);
+
+    void deleteByIdAndUser(Long id, Users user);
 }

--- a/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresService.java
@@ -7,6 +7,7 @@ import com.example.ReviewZIP.domain.user.UsersRepository;
 import com.example.ReviewZIP.domain.userStores.dto.request.UserStoresRequestDto;
 import com.example.ReviewZIP.domain.userStores.dto.response.UserStoresResponseDto;
 import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
+import com.example.ReviewZIP.global.response.exception.handler.UserStoresHandler;
 import com.example.ReviewZIP.global.response.exception.handler.UsersHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,7 +31,11 @@ public class UserStoresService {
         UserStores userStores = UserStoresConverter.toEntity(dto);
         userStores.setUser(user);
 
-        userStoresRepository.save(userStores);
+        try {
+            userStoresRepository.save(userStores);
+        } catch (Exception e) {
+            throw new UserStoresHandler(ErrorStatus.USER_STORES_CREATE_FAIL);
+        }
 
     }
 
@@ -51,7 +56,11 @@ public class UserStoresService {
     @Transactional
     public void deleteUserStores(Long userStoreId) {
         Users user = usersRepository.findById(1L).orElseThrow(()-> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
-        userStoresRepository.deleteByIdAndUser(userStoreId, user);
+        try {
+            userStoresRepository.deleteByIdAndUser(userStoreId, user);
+        } catch (Exception e) {
+            throw new UserStoresHandler(ErrorStatus.USER_STORES_DELETE_FAIL);
+        }
     }
 
 

--- a/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/userStores/UserStoresService.java
@@ -48,6 +48,12 @@ public class UserStoresService {
         return userStoresRepository.existsUserStoresByLatitudeAndLongitude(lat,lon);
     }
 
+    @Transactional
+    public void deleteUserStores(Long userStoreId) {
+        Users user = usersRepository.findById(1L).orElseThrow(()-> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        userStoresRepository.deleteByIdAndUser(userStoreId, user);
+    }
+
 
 
 

--- a/src/main/java/com/example/ReviewZIP/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/com/example/ReviewZIP/global/response/code/resultCode/ErrorStatus.java
@@ -70,7 +70,13 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401", "유효하지 않은 ACCESS 토큰입니다."),
     EXPIRED_MEMBER_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH402", "만료된 JWT 토큰입니다."),
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH403", "지원되지 않는 JWT 토큰입니다."),
-    ILLEGALARGUMENT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH404", "잘못된 JWT 토큰입니다.");
+    ILLEGALARGUMENT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH404", "잘못된 JWT 토큰입니다."),
+
+    // UserStores
+    USER_STORES_CREATE_FAIL(HttpStatus.BAD_REQUEST,"USERSTORE401", "유저 관심장소 생성에 실패하였습니다."),
+    USER_STORES_DELETE_FAIL(HttpStatus.BAD_REQUEST,"USERSTORE402", "유저 관심장소 삭제에 실패하였습니다."),
+    USER_STORES_NOT_FOUND(HttpStatus.NOT_FOUND, "USERSTORE403", "존재하지 않는 유저 관심장소 입니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/ReviewZIP/global/response/exception/handler/UserStoresHandler.java
+++ b/src/main/java/com/example/ReviewZIP/global/response/exception/handler/UserStoresHandler.java
@@ -1,0 +1,11 @@
+package com.example.ReviewZIP.global.response.exception.handler;
+
+import com.example.ReviewZIP.global.response.code.BaseErrorCode;
+import com.example.ReviewZIP.global.response.exception.GeneralException;
+
+public class UserStoresHandler extends GeneralException {
+    public UserStoresHandler(BaseErrorCode code) {
+        super(code);
+    }
+
+}


### PR DESCRIPTION
# 상세 구현 내용
userStores의 아이디를 입력받아 삭제합니다. 특정 유저의 관심장소 목록 조회 시 storeId가 반환되는데 해당 값을 입력하면 됩니다.

## userStoresService
```java
 @Transactional
    public void deleteUserStores(Long userStoreId) {
        Users user = usersRepository.findById(1L).orElseThrow(()-> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
        userStoresRepository.deleteByIdAndUser(userStoreId, user);
    }
```
request에서는 storeId 값만 입력받고 토큰 값에 있는 유저 정보를 통해 유저를 반환 후 storeId와 User 객체의 정보로 userStores를 삭제합니다.

