### PR TITLE
[Refactor] 게시글 생성 API 수정

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsConverter.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsConverter.java
@@ -22,6 +22,7 @@ public class PostsConverter {
 
     public static FollowsRepository followsRepository;
 
+
     public PostsConverter(UsersRepository usersRepository, FollowsRepository followsRepository) {
         this.usersRepository = usersRepository;
         this.followsRepository = followsRepository;
@@ -73,6 +74,7 @@ public class PostsConverter {
                 .tagName(postHashtags.getHashtag())
                 .build();
     }
+
     public static PostResponseDto.PostInfoDto toPostInfoResultDto(Posts post, Users user, boolean checkLike, boolean checkScrab, String createdAt){
         PostResponseDto.UserInfoDto userInfoDto = toUserInfoDto(post.getUser());
 
@@ -121,4 +123,12 @@ public class PostsConverter {
         
         return postUserLikeDtoList;
     }
+
+    public static PostHashtags toPostHashtags(String hashtag, Posts posts){
+        return PostHashtags.builder()
+                .hashtag(hashtag)
+                .post(posts)
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsService.java
@@ -20,7 +20,10 @@ import com.example.ReviewZIP.global.redis.RedisService;
 import com.example.ReviewZIP.global.response.ApiResponse;
 import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
 import com.example.ReviewZIP.global.response.code.resultCode.SuccessStatus;
-import com.example.ReviewZIP.global.response.exception.handler.*;
+import com.example.ReviewZIP.global.response.exception.handler.PostHashtagsHandler;
+import com.example.ReviewZIP.global.response.exception.handler.PostLikesHandler;
+import com.example.ReviewZIP.global.response.exception.handler.PostsHandler;
+import com.example.ReviewZIP.global.response.exception.handler.UsersHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -37,6 +40,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.example.ReviewZIP.domain.post.PostsConverter.toPostHashtags;
 
 @Service
 @RequiredArgsConstructor
@@ -76,8 +81,21 @@ public class PostsService {
 
         newPost.getPostImageList().addAll(images); // 양방향 연관관계 설정
 
+
+        // PostHashtags 객체 변환
+        List<String> hashtagList = request.getHashtags();
+        List<PostHashtags> postHashtagList = hashtagList.stream()
+                .map(hashtag -> toPostHashtags(hashtag, newPost))
+                .collect(Collectors.toList());
+
+        List<PostHashtags> hashtag = postHashtagList.stream()
+                .map(postHashtag -> postHashtagsRepository.save(postHashtag))
+                .collect(Collectors.toList());
+
         return PostsConverter.toPostInfoResultDto(newPost, currentUser, false, false, newPost.getCreatedAt().toString());
     }
+
+
 
     public List<PostHashtags> searchPostByHashtag (Long hashtagId){
         PostHashtags postHashtags = postHashtagsRepository.findById(hashtagId).orElseThrow(()->new PostHashtagsHandler(ErrorStatus.HASHTAG_NOT_FOUND));

--- a/src/main/java/com/example/ReviewZIP/domain/post/dto/request/PostRequestDto.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/dto/request/PostRequestDto.java
@@ -17,6 +17,7 @@ public class PostRequestDto {
     public static class CreatedPostRequestDto {
         private String comment;
         private Double point;
+        private List<String> hashtags = new ArrayList<>();
         private List<Long> imageIds = new ArrayList<>();
         private StoreRequestDto.StoreInfoDto storeInfo;
     }


### PR DESCRIPTION
# 수정 사항
---
- 게시글 생성시 CreatedPostRequestDto에 해시태그의 값을 배열로 받도록 하였습니다.

</br>

## PostRequestDto

```java
public class PostRequestDto {
    @Getter
    @Builder
    @NoArgsConstructor
    @AllArgsConstructor
    public static class CreatedPostRequestDto {
        private String comment;
        private Double point;
        private List<String> hashtags = new ArrayList<>();
        private List<Long> imageIds = new ArrayList<>();
        private StoreRequestDto.StoreInfoDto storeInfo;
    }
}
```

</br>

## PostsService

```java
public PostResponseDto.PostInfoDto createPost(Long userId, PostRequestDto.CreatedPostRequestDto request) {

---생략---

        // PostHashtags 객체 변환
        List<String> hashtagList = request.getHashtags();
        List<PostHashtags> postHashtagList = hashtagList.stream()
                .map(hashtag -> toPostHashtags(hashtag, newPost))
                .collect(Collectors.toList());

        List<PostHashtags> hashtag = postHashtagList.stream()
                .map(postHashtag -> postHashtagsRepository.save(postHashtag))
                .collect(Collectors.toList());

---생략---

}
```

- 제가 stream 쓰는게 익숙해서 자주 쓰는데 복잡해보이지만 생각보다 간단합니다...! Repository는 Service단에서 처리하고싶어 한 번 더 stream을 사용하였습니다.


