### PR TITLE
[Feat] 토큰 만료 후 토큰 재발급 API

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenController.java
@@ -2,7 +2,9 @@ package com.example.ReviewZIP.domain.token;
 
 import com.example.ReviewZIP.domain.token.dto.request.KakaoRequestDto;
 import com.example.ReviewZIP.domain.token.dto.request.LoginRequestDto;
+import com.example.ReviewZIP.domain.token.dto.request.RefreshTokenRequestDto;
 import com.example.ReviewZIP.domain.token.dto.request.SignUpRequestDto;
+import com.example.ReviewZIP.domain.token.dto.response.RegenerateTokenResponseDto;
 import com.example.ReviewZIP.domain.token.dto.response.TokenDto;
 import com.example.ReviewZIP.global.response.ApiResponse;
 import com.example.ReviewZIP.global.response.code.resultCode.SuccessStatus;
@@ -47,6 +49,18 @@ public class RefreshTokenController {
     })
     public ApiResponse<TokenDto> login(@RequestBody LoginRequestDto loginRequestDto) {
         return ApiResponse.onSuccess(refreshTokenService.login(loginRequestDto));
+    }
+
+    @PostMapping("/refresh")
+    @Operation(summary = "토큰 만료시 AccessToken 재발급", description = "RefreshToken을 받아 AccessToken 재발급, RefreshTokenRequestDto & RegenerateTokenResponseDto 이용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH407", description = "리프레시 토큰이 유효하지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "토큰 속 유저 정보가 유효하지 않습니다."),
+    })
+    public ApiResponse<RegenerateTokenResponseDto> refresh(@RequestBody RefreshTokenRequestDto request){
+        String accessToken = refreshTokenService.regenerateAccessToken(request);
+        return ApiResponse.onSuccess(RefreshTokenConverter.toRegenerateTokenDto(accessToken));
     }
 
     @PostMapping("/kakao/login")

--- a/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenController.java
@@ -56,7 +56,7 @@ public class RefreshTokenController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH407", description = "리프레시 토큰이 유효하지 않습니다."),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "토큰 속 유저 정보가 유효하지 않습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH405", description = "토큰 속 유저 정보가 유효하지 않습니다."),
     })
     public ApiResponse<RegenerateTokenResponseDto> refresh(@RequestBody RefreshTokenRequestDto request){
         String accessToken = refreshTokenService.regenerateAccessToken(request);

--- a/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenConverter.java
+++ b/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenConverter.java
@@ -1,0 +1,11 @@
+package com.example.ReviewZIP.domain.token;
+
+import com.example.ReviewZIP.domain.token.dto.response.RegenerateTokenResponseDto;
+
+public class RefreshTokenConverter {
+    public static RegenerateTokenResponseDto toRegenerateTokenDto(String token){
+        return RegenerateTokenResponseDto.builder()
+                .accessToken(token)
+                .build();
+    }
+}

--- a/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenRepository.java
+++ b/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByKey(String key);
+
+    Optional<RefreshToken> findByValue(String token);
 }

--- a/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenService.java
@@ -171,7 +171,7 @@ public class RefreshTokenService {
 
     public String regenerateAccessToken(RefreshTokenRequestDto request){
         RefreshToken refreshToken = refreshTokenRepository.findByValue(request.getRefreshToken()).orElseThrow(()-> new GeneralHandler(ErrorStatus.INVALID_REFRESH_TOKEN));
-        Users user = usersRepository.findByEmail(refreshToken.getKey()).orElseThrow(()-> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+        Users user = usersRepository.findByEmail(refreshToken.getKey()).orElseThrow(()-> new UsersHandler(ErrorStatus.JWT_NO_USER_INFO));
 
         return jwtProvider.regenerateAccessToken(user);
     }

--- a/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenService.java
+++ b/src/main/java/com/example/ReviewZIP/domain/token/RefreshTokenService.java
@@ -2,6 +2,7 @@ package com.example.ReviewZIP.domain.token;
 
 import com.example.ReviewZIP.domain.token.dto.request.KakaoRequestDto;
 import com.example.ReviewZIP.domain.token.dto.request.LoginRequestDto;
+import com.example.ReviewZIP.domain.token.dto.request.RefreshTokenRequestDto;
 import com.example.ReviewZIP.domain.token.dto.request.SignUpRequestDto;
 import com.example.ReviewZIP.domain.token.dto.response.SignUpResponseDto;
 import com.example.ReviewZIP.domain.token.dto.response.TokenDto;
@@ -10,6 +11,7 @@ import com.example.ReviewZIP.domain.user.Users;
 import com.example.ReviewZIP.domain.user.UsersRepository;
 import com.example.ReviewZIP.global.jwt.JwtProvider;
 import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
+import com.example.ReviewZIP.global.response.exception.handler.GeneralHandler;
 import com.example.ReviewZIP.global.response.exception.handler.UsersHandler;
 import com.example.ReviewZIP.global.security.UserDetailsImpl;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -165,5 +167,12 @@ public class RefreshTokenService {
 
         refreshTokenRepository.save(refreshToken);
         return tokenDto;
+    }
+
+    public String regenerateAccessToken(RefreshTokenRequestDto request){
+        RefreshToken refreshToken = refreshTokenRepository.findByValue(request.getRefreshToken()).orElseThrow(()-> new GeneralHandler(ErrorStatus.INVALID_REFRESH_TOKEN));
+        Users user = usersRepository.findByEmail(refreshToken.getKey()).orElseThrow(()-> new UsersHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return jwtProvider.regenerateAccessToken(user);
     }
 }

--- a/src/main/java/com/example/ReviewZIP/domain/token/dto/request/RefreshTokenRequestDto.java
+++ b/src/main/java/com/example/ReviewZIP/domain/token/dto/request/RefreshTokenRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.ReviewZIP.domain.token.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshTokenRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/example/ReviewZIP/domain/token/dto/response/RegenerateTokenResponseDto.java
+++ b/src/main/java/com/example/ReviewZIP/domain/token/dto/response/RegenerateTokenResponseDto.java
@@ -1,0 +1,14 @@
+package com.example.ReviewZIP.domain.token.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RegenerateTokenResponseDto {
+    private String accessToken;
+}

--- a/src/main/java/com/example/ReviewZIP/global/jwt/JwtProvider.java
+++ b/src/main/java/com/example/ReviewZIP/global/jwt/JwtProvider.java
@@ -1,6 +1,7 @@
 package com.example.ReviewZIP.global.jwt;
 
 import com.example.ReviewZIP.domain.token.dto.response.TokenDto;
+import com.example.ReviewZIP.domain.user.Users;
 import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
 import com.example.ReviewZIP.global.response.exception.handler.UsersHandler;
 import io.jsonwebtoken.*;
@@ -151,6 +152,21 @@ public class JwtProvider {
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
+    }
+
+    public String regenerateAccessToken(Users user){
+        long now = (new Date()).getTime();
+
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRATION_TIME);
+        String accessToken  = Jwts.builder()
+                .setSubject(user.getEmail())
+                .claim(AUTHORITIES_KEY, "ROLE_USER")
+                .claim("userId", user.getId())
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return accessToken;
     }
 }
 

--- a/src/main/java/com/example/ReviewZIP/global/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/com/example/ReviewZIP/global/response/code/resultCode/ErrorStatus.java
@@ -78,6 +78,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ILLEGAL_ARGUMENT_TOKEN(HttpStatus.BAD_REQUEST, "AUTH404", "잘못된 JWT 토큰입니다."),
     JWT_NO_USER_INFO(HttpStatus.UNAUTHORIZED, "AUTH405", "토큰에 사용자 정보가 없습니다."),
     JWT_NO_AUTH_INFO(HttpStatus.UNAUTHORIZED, "AUTH406", "권한 정보가 없는 토큰입니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH407", "유효하지 않은 REFRESH 토큰입니다."),
 
 
     // UserStores


### PR DESCRIPTION
# 구현 설명
---

## RefreshTokenContoroller

- RefreshTokenRquestDto에는 refresh token값이 담겨서 옵니다. 로직은 만료된 토큰 사용시 프론트로 에러가 발생하게되는데 그때 실행될 기능이라고 이해하시면 될 거 같습니다.

```java
    @PostMapping("/refresh")
    @Operation(summary = "토큰 만료시 AccessToken 재발급", description = "RefreshToken을 받아 AccessToken 재발급, RefreshTokenRequestDto & RegenerateTokenResponseDto 이용")
    @ApiResponses({
            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH407", description = "리프레시 토큰이 유효하지 않습니다."),
            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "토큰 속 유저 정보가 유효하지 않습니다."),
    })
    public ApiResponse<RegenerateTokenResponseDto> refresh(@RequestBody RefreshTokenRequestDto request){
        String accessToken = refreshTokenService.regenerateAccessToken(request);
        return ApiResponse.onSuccess(RefreshTokenConverter.toRegenerateTokenDto(accessToken));
    }
```

</br>

## RefreshTokenService

- 현재 RefreshToken 엔티티는 key인 email과 value인 refreshtoken으로 이루어져있어 먼저 findByValue로 해당 토큰과 같은 값을 갖는 객체를 찾은 뒤 해당 토큰의 key(email)값으로 Users 객체를 찾도록 하였습니다. 후엔 regenerageAccessToken을 실행하는데요.

```java
    public String regenerateAccessToken(RefreshTokenRequestDto request){
        RefreshToken refreshToken = refreshTokenRepository.findByValue(request.getRefreshToken()).orElseThrow(()-> new GeneralHandler(ErrorStatus.INVALID_REFRESH_TOKEN));
        Users user = usersRepository.findByEmail(refreshToken.getKey()).orElseThrow(()-> new UsersHandler(ErrorStatus.USER_NOT_FOUND));

        return jwtProvider.regenerateAccessToken(user);
    }
```

</br>

## JwtProvider

```java
    public String regenerateAccessToken(Users user){
        long now = (new Date()).getTime();

        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRATION_TIME);
        String accessToken  = Jwts.builder()
                .setSubject(user.getEmail())
                .claim(AUTHORITIES_KEY, "ROLE_USER")
                .claim("userId", user.getId())
                .setExpiration(accessTokenExpiresIn)
                .signWith(key, SignatureAlgorithm.HS256)
                .compact();

        return accessToken;
    }
```
- 이 함수는 유저정보 받아서 access token 다시 만들어주는 과정입니다.

- 그리고 해당 access token은 컨트롤러에서 converter를 이용하여 RegenerateTokenResponseDto로 변환되어 프론트로 보내지게 됩니다.

</br>

# 데이터 베이스
---

```json
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "성공입니다.",
  "result": {
    "userId": 117,
    "name": "김민우",
    "nickname": "김민우",
    "profileUrl": "https://reviewzipbucket.s3.ap-northeast-2.amazonaws.com/ReviewImage/4356d632-4e06-483d-9629-90dad53aaee6.png",
    "postNum": 4,
    "followingNum": 1,
    "followerNum": 1
  }
}
```
- RefreshToken 테이블에서 김민우 유저의 refresh token을 가지고 얻은 access token으로 `나의 정보 가져오기 API` 실행 후 결과입니다!


