### PR TITLE
[Refactor] 게시글 가져오기 API

### DIFF
--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsController.java
@@ -64,6 +64,7 @@ public class PostsController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "POST401", description = "해당 게시물이 존재하지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "STORE401", description = "게시물에 장소객체가 매핑되어있지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "postId", description = "게시글의 아이디"),

--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsConverter.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsConverter.java
@@ -80,8 +80,8 @@ public class PostsConverter {
                 .build();
     }
 
-    public static PostResponseDto.StoreInfoDto toStoreInfoDto(Stores store){
-        return PostResponseDto.StoreInfoDto.builder()
+    public static StoreRequestDto.StoreInfoDto toStoreInfoDto(Stores store){
+        return StoreRequestDto.StoreInfoDto.builder()
                 .latitude(store.getLatitude())
                 .longitude(store.getLongitude())
                 .name(store.getName())
@@ -99,7 +99,7 @@ public class PostsConverter {
                 .map(PostsConverter::toHashtagDto).collect(Collectors.toList());
 
         Stores store = storesRepository.findByPost(post).orElseThrow(()-> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));
-        PostResponseDto.StoreInfoDto postInfoDto = toStoreInfoDto(store);
+        StoreRequestDto.StoreInfoDto postInfoDto = toStoreInfoDto(store);
 
         boolean mine = false;
         if(user.getId().equals(post.getUser().getId())) {

--- a/src/main/java/com/example/ReviewZIP/domain/post/PostsConverter.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/PostsConverter.java
@@ -6,9 +6,12 @@ import com.example.ReviewZIP.domain.post.dto.request.PostRequestDto;
 import com.example.ReviewZIP.domain.post.dto.response.PostResponseDto;
 import com.example.ReviewZIP.domain.postHashtag.PostHashtags;
 import com.example.ReviewZIP.domain.store.Stores;
+import com.example.ReviewZIP.domain.store.StoresRepository;
 import com.example.ReviewZIP.domain.store.dto.request.StoreRequestDto;
 import com.example.ReviewZIP.domain.user.Users;
 import com.example.ReviewZIP.domain.user.UsersRepository;
+import com.example.ReviewZIP.global.response.code.resultCode.ErrorStatus;
+import com.example.ReviewZIP.global.response.exception.handler.StoreHandler;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -21,11 +24,13 @@ public class PostsConverter {
     public static UsersRepository usersRepository;
 
     public static FollowsRepository followsRepository;
+    public static StoresRepository storesRepository;
 
 
-    public PostsConverter(UsersRepository usersRepository, FollowsRepository followsRepository) {
+    public PostsConverter(UsersRepository usersRepository, FollowsRepository followsRepository, StoresRepository storesRepository, StoresRepository storesRepository1) {
         this.usersRepository = usersRepository;
         this.followsRepository = followsRepository;
+        this.storesRepository = storesRepository1;
     }
 
     public static Posts toPostDto(PostRequestDto.CreatedPostRequestDto PostDto, Users user) {
@@ -75,6 +80,15 @@ public class PostsConverter {
                 .build();
     }
 
+    public static PostResponseDto.StoreInfoDto toStoreInfoDto(Stores store){
+        return PostResponseDto.StoreInfoDto.builder()
+                .latitude(store.getLatitude())
+                .longitude(store.getLongitude())
+                .name(store.getName())
+                .addressName(store.getAddress_name())
+                .roadAddressName(store.getRoad_address_name())
+                .build();
+    }
     public static PostResponseDto.PostInfoDto toPostInfoResultDto(Posts post, Users user, boolean checkLike, boolean checkScrab, String createdAt){
         PostResponseDto.UserInfoDto userInfoDto = toUserInfoDto(post.getUser());
 
@@ -83,6 +97,9 @@ public class PostsConverter {
 
         List<PostResponseDto.HashtagDto> hashtagList = post.getPostHashtagList().stream()
                 .map(PostsConverter::toHashtagDto).collect(Collectors.toList());
+
+        Stores store = storesRepository.findByPost(post).orElseThrow(()-> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));
+        PostResponseDto.StoreInfoDto postInfoDto = toStoreInfoDto(store);
 
         boolean mine = false;
         if(user.getId().equals(post.getUser().getId())) {
@@ -103,6 +120,7 @@ public class PostsConverter {
                 .user(userInfoDto)
                 .checkMine(mine)
                 .postImages(imageListDto)
+                .store(postInfoDto)
                 .createdAt(createdAt)
                 .build();
     }

--- a/src/main/java/com/example/ReviewZIP/domain/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/dto/response/PostResponseDto.java
@@ -41,6 +41,18 @@ public class PostResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class StoreInfoDto{
+        private String latitude;
+        private String longitude;
+        private String name;
+        private String roadAddressName;
+        private String addressName;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class PostInfoDto{
         private Long postId;
         private String comment;
@@ -55,6 +67,7 @@ public class PostResponseDto {
         private UserInfoDto user;
         private List<HashtagDto> hashtags;
         private List<ImageDto> postImages;
+        private StoreInfoDto store;
     }
 
     @Getter

--- a/src/main/java/com/example/ReviewZIP/domain/post/dto/response/PostResponseDto.java
+++ b/src/main/java/com/example/ReviewZIP/domain/post/dto/response/PostResponseDto.java
@@ -1,5 +1,6 @@
 package com.example.ReviewZIP.domain.post.dto.response;
 
+import com.example.ReviewZIP.domain.store.dto.request.StoreRequestDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,18 +42,6 @@ public class PostResponseDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class StoreInfoDto{
-        private String latitude;
-        private String longitude;
-        private String name;
-        private String roadAddressName;
-        private String addressName;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class PostInfoDto{
         private Long postId;
         private String comment;
@@ -67,7 +56,7 @@ public class PostResponseDto {
         private UserInfoDto user;
         private List<HashtagDto> hashtags;
         private List<ImageDto> postImages;
-        private StoreInfoDto store;
+        private StoreRequestDto.StoreInfoDto store;
     }
 
     @Getter

--- a/src/main/java/com/example/ReviewZIP/domain/store/StoresRepository.java
+++ b/src/main/java/com/example/ReviewZIP/domain/store/StoresRepository.java
@@ -1,7 +1,13 @@
 package com.example.ReviewZIP.domain.store;
 
+import com.example.ReviewZIP.domain.post.Posts;
 import com.example.ReviewZIP.domain.user.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface StoresRepository extends JpaRepository<Stores, Long> {
+    Optional<Stores> findByPost(Posts post);
 }

--- a/src/main/java/com/example/ReviewZIP/domain/user/UsersController.java
+++ b/src/main/java/com/example/ReviewZIP/domain/user/UsersController.java
@@ -153,6 +153,7 @@ public class UsersController {
     @Operation(summary = "나의 게시물 목록 가져오기 API",description = "나의 게시글들을 반환, UserInfoDto & ImageDto & HashtagDto & PostInfoDto 이용")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "STORE401", description = "게시물에 장소객체가 매핑되어있지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     public ApiResponse<List<PostResponseDto.PostInfoDto>> getUserPostList(@AuthenticationPrincipal UserDetails user){
         List<Posts> postList = usersService.getPostList(usersService.getUserId(user));
@@ -165,6 +166,7 @@ public class UsersController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "토큰에 해당하는 유저 없음",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "STORE401", description = "게시물에 장소객체가 매핑되어있지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     public ApiResponse<List<PostResponseDto.PostInfoDto>> getUserScrabList(@AuthenticationPrincipal UserDetails user) {
         List<Scrabs> scrabList = usersService.getScrabList(usersService.getUserId(user));
@@ -177,6 +179,7 @@ public class UsersController {
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "토큰에 해당하는 유저 없음",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "STORE401", description = "게시물에 장소객체가 매핑되어있지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
             @Parameter(name = "userId", description = "유저의 아이디"),
@@ -193,6 +196,7 @@ public class UsersController {
      @ApiResponses({
              @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
              @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "USER404", description = "유저가 존재하지 않습니다",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "STORE401", description = "게시물에 장소객체가 매핑되어있지 않습니다.",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
      })
      @Parameters({
              @Parameter(name = "userId", description = "유저의 아이디"),

--- a/src/main/java/com/example/ReviewZIP/global/response/exception/handler/StoreHandler.java
+++ b/src/main/java/com/example/ReviewZIP/global/response/exception/handler/StoreHandler.java
@@ -1,0 +1,9 @@
+package com.example.ReviewZIP.global.response.exception.handler;
+
+import com.example.ReviewZIP.global.response.code.BaseErrorCode;
+
+public class StoreHandler extends GeneralHandler{
+    public StoreHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}


### PR DESCRIPTION
# 수정 사항
---

- 게시글에 저장된 장소를 지도로 보여주기 위하여 게시글에 지정된 가게의 정보를 반환하도록 수정하였습니다.

## PostResponseDto

```java
    @Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class StoreInfoDto{
        private String latitude;
        private String longitude;
        private String name;
        private String roadAddressName;
        private String addressName;
    }

    @Builder
    @Getter
    @NoArgsConstructor
    @AllArgsConstructor
    public static class PostInfoDto{
        private Long postId;
        private String comment;
        private Double point;
        private Integer likeNum;
        private Integer scrabNum;
        private Integer hashtagNum;
        private boolean checkLike;
        private boolean checkScrab;
        private boolean checkMine;
        private String createdAt;
        private UserInfoDto user;
        private List<HashtagDto> hashtags;
        private List<ImageDto> postImages;
        private StoreInfoDto store;
    }
```

</br>

## PostsConverter

- 만약 게시글에 장소가 없을 경우 에러가 발생하도록 하였습니다. 게시글 생성시 프론트에서 장소 설정하지 않으면 오류가 발생하므로 그럴 일 없지만 더미데이터로 인한 에러를 위하여 추가하였습니다.

```java
public static PostResponseDto.PostInfoDto toPostInfoResultDto(Posts post, Users user, boolean checkLike, boolean checkScrab, String createdAt){

   --- 생략 ---

        Stores store = storesRepository.findByPost(post).orElseThrow(()-> new StoreHandler(ErrorStatus.STORE_NOT_FOUND));
        PostResponseDto.StoreInfoDto postInfoDto = toStoreInfoDto(store);

   --- 생략 ---
}
```


